### PR TITLE
[#169176122] Update links to open in new window

### DIFF
--- a/lib/formats/promote_link.js
+++ b/lib/formats/promote_link.js
@@ -6,6 +6,8 @@ class PromoteLink extends Link {
   static create(value) {
     let node = super.create(value);
     node.setAttribute('href', LinkParser.ensureProtocol(node.getAttribute('href')));
+    node.setAttribute("target", "_blank");
+    node.setAttribute("rel", "noopener noreferrer");
     return node;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "promote-editor",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "description": "Editor based on Quilljs with Promote additions",
   "main": "lib/index.js",
   "scripts": {

--- a/test/test_promote_link.js
+++ b/test/test_promote_link.js
@@ -9,6 +9,11 @@ describe('PromoteLink', () => {
   it('add https if protocol is missing', () => {
     let subject = PromoteLink.create("example.org");
     expect(subject.getAttribute('href')).to.equal("https://example.org");
+
+  it("includes blank noopener noreferrer attributes", () => {
+    let subject = PromoteLink.create("https://example.org");
+    expect(subject.getAttribute("target")).to.equal("_blank");
+    expect(subject.getAttribute("rel")).to.equal("noopener noreferrer");
   });
 });
 


### PR DESCRIPTION
The goal of this story is to update internal links to external sites
to use `_blank`, opening the site in a new window, with `noopener
norefferer` to prevent hijacking of the origin tab (Promote in this
case).

This commit progresses this story by updating Quill links to have
these attributes.

<img width="1439" alt="Screenshot 2020-04-21 at 11 22 31" src="https://user-images.githubusercontent.com/6812594/79851376-81efe500-83c5-11ea-8b44-68387bf13fbc.png">

Note running `nom test` fails due to unrelated test which broke in e0f1023fc2b41002e469090e4452cf693e46a7c2 (I'm following up with how to fix).