### PR TITLE
[#172443231] Add jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,35 @@
+#!groovy
+
+pipeline {
+  agent any
+
+  stages {
+    stage('Dependencies') {
+      steps {
+        sh '''#!/bin/bash -le
+          npm install
+          '''
+      }
+    }
+
+    stage('Tests') {
+      steps {
+        sh '''#!/bin/bash -le
+          npm test
+          '''
+      }
+    }
+
+    stage('Create package') {
+      when {
+        buildingTag()
+      }
+      steps {
+        sh '''#!/bin/bash -le
+          npm run dist
+          '''
+        archiveArtifacts artifacts: 'dist/promote-editor.js', fingerprint: true
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -15,16 +15,34 @@ Rich content editor based on [Quilljs](https://quilljs.com/).
 
 ## Running tests
 
-``` bash
+```bash
 $ npm test
 ```
 
 ## Bundling
 
-To create a new version of `dist/promote-editor.js`,
-first bump version in `package.json`, then run:
+To create a new version of `dist/promote-editor.js`:
+First bump version in `package.json`,
+preferably edit this version directly on master and push it:
 
-``` bash
+```bash
+git checkout master
+git pull
+# edit package.json
+git add package.json
+git commit -v "Bump version"
+git push
+# use the correct version
+git tag -a v0.x.y
+git push --tags
+```
+
+Then either run this,
+or trigger the tag build on CI to generate the asset there.
+
+
+```bash
 $ npm run dist
 ```
 
+<https://ci.promoteapp.net/blue/organizations/jenkins/gems%2Fpromote-quill/branches>


### PR DESCRIPTION
The tests only pass with the previous pr that fixes the tests ans switches to firefox. However, this can be merged first.

It succeeds when the tests are working (temporary based this commit ontop of that pr)
![2020-04-21-224242_1571x986_scrot](https://user-images.githubusercontent.com/81471/79911880-6d413a80-8421-11ea-964b-d90477561611.png)

And it shows failure when the tests aren't working
![2020-04-21-224507_1692x797_scrot](https://user-images.githubusercontent.com/81471/79912137-d9bc3980-8421-11ea-8778-d26185dd43c2.png)
